### PR TITLE
Modify Zotero re_pattern to match version 6.0

### DIFF
--- a/Zotero/Zotero.download.recipe
+++ b/Zotero/Zotero.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://www.zotero.org/support/changelog</string>
 				<key>re_pattern</key>
-				<string>Changes in (?P&lt;version&gt;\d\.\d\.\d{2}\.\d)</string>
+				<string>Changes in (?P&lt;version&gt;\d\.[0-9\.]+)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This pattern is not as specific as the current one but should catch any version number format as long as it contains only numbers or dots.